### PR TITLE
Use two-way binding on color property

### DIFF
--- a/src/AvaloniaWinUI.ColorPicker/ColorPicker.Properties.cs
+++ b/src/AvaloniaWinUI.ColorPicker/ColorPicker.Properties.cs
@@ -242,7 +242,7 @@ namespace AvaloniaWinUI.ColorPicker
         // Returns:
         //     The identifier for the Color dependency property.
         public static readonly StyledProperty<Color> ColorProperty =
-            AvaloniaProperty.Register<ColorPicker, Color>(nameof(Color), Colors.White);
+            AvaloniaProperty.Register<ColorPicker, Color>(nameof(Color), Colors.White, defaultBindingMode: Avalonia.Data.BindingMode.TwoWay);
         //
         // Summary:
         //     Identifies the ColorSpectrumComponents dependency property.


### PR DESCRIPTION
Great job on the color picker!

Previously, the color property did not specify the binding mode. Since the color property is a two-way property, this should be the default.